### PR TITLE
Add DSPy GEPA prompt optimization toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 /.next/
 /out/
 
+# python tooling
+/.python_lib/
+
 # production
 /build
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## DSPy prompt optimization
+
+The workbench now supports optimizing Gemini prompts with **DSPy 3 + GEPA** in addition to the original handwritten prompt.
+
+1. Install the Python tooling once per environment:
+   ```bash
+   pip install -r python/requirements.txt
+   ```
+2. Provide a `GEMINI_API_KEY` so both Next.js and DSPy can reach Gemini models.
+3. In the **Options** panel use the new *Prompt Strategy* toggle to switch between manual prompts and DSPy GEPA optimization.
+4. Generation results will surface which strategy ran along with GEPA coverage/score stats.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/api/gemini/generate/route.ts
+++ b/app/api/gemini/generate/route.ts
@@ -3,45 +3,185 @@ import { NextResponse } from "next/server";
 import { createUserContent, createPartFromUri } from "@google/genai";
 import { ai } from "@/lib/gemini";
 import { getSchemaConfig } from "@/lib/geminiPrompts";
-import { SchemaType } from "@/lib/types";
 import { getErrorMessage } from "@/lib/errors";
+import { optimizePromptWithDSPy, type DspyOptimizationPayload, type PromptBlueprint, type PromptShotSummary } from "@/lib/dspy";
+import { PromptMode, PromptOptimizationMeta, SchemaType } from "@/lib/types";
 
 export const runtime = "nodejs";
 
 // Types the client sends
 type VideoRef = { uri: string; mimeType: string };
 type ImgRef = { id: string; uri: string; mimeType: string; timecode: string };
+type DspyOptions = Partial<
+  Pick<
+    DspyOptimizationPayload,
+    | "auto"
+    | "maxMetricCalls"
+    | "model"
+    | "reflectionModel"
+    | "temperature"
+    | "reflectionTemperature"
+    | "maxTokens"
+    | "reflectionMaxTokens"
+    | "seed"
+    | "initialInstructions"
+    | "timeoutMs"
+    | "debug"
+  >
+>;
+
+type RequestBody = {
+  video: VideoRef;
+  screenshots: ImgRef[];
+  enforceSchema: boolean;
+  titleHint?: string;
+  schemaType?: SchemaType;
+  promptMode?: PromptMode;
+  shots?: PromptShotSummary[];
+  dspyOptions?: DspyOptions;
+};
 
 const FALLBACK_ERROR = "Generation failed";
 
 export async function POST(req: Request) {
   try {
-    const body = (await req.json()) as {
-      video: VideoRef;
-      screenshots: ImgRef[];
-      enforceSchema: boolean;
-      titleHint?: string;
-      schemaType?: SchemaType;
-    };
+    const body = (await req.json()) as RequestBody;
 
-    const { video, screenshots, enforceSchema, titleHint, schemaType } = body;
+    const video = body.video;
+    const screenshots = body.screenshots;
+    const enforceSchema = body.enforceSchema;
+    const titleHint = body.titleHint;
+    const schemaType = body.schemaType;
+    const promptMode: PromptMode = body.promptMode === "dspy" ? "dspy" : "manual";
+    const shotsMeta: PromptShotSummary[] = (body.shots ?? []).map((shot) => ({ ...shot }));
+    const dspyOptions: DspyOptions = body.dspyOptions ?? {};
 
     const mode: SchemaType = schemaType === "meetingSummary" ? "meetingSummary" : "tutorial";
-    const schemaConfig = getSchemaConfig(mode);
+    const tutorialConfig = getSchemaConfig("tutorial");
+    const meetingConfig = getSchemaConfig("meetingSummary");
+    const schemaConfig = mode === "tutorial" ? tutorialConfig : meetingConfig;
+
+    const toBlueprint = (config: ReturnType<typeof getSchemaConfig>): PromptBlueprint => ({
+      persona: config.persona,
+      requirements: config.requirements,
+      fallbackOutput: config.fallbackOutput,
+      hintLabel: config.hintLabel,
+    });
+
+    let personaText = schemaConfig.persona;
+    let requirementsText = schemaConfig.requirements;
+    let fallbackOutputText = schemaConfig.fallbackOutput;
+    let styleGuideText: string | undefined;
+
+    let promptMeta: PromptOptimizationMeta = {
+      requestedMode: promptMode,
+      appliedMode: "manual",
+      message: promptMode === "dspy" ? "DSPy prompt unavailable – manual instructions used." : "Manual Gemini prompt used.",
+    };
+
+    if (promptMode === "dspy") {
+      try {
+        const optimizationPayload: DspyOptimizationPayload = {
+          schemaType: mode,
+          enforceSchema,
+          titleHint,
+          shots: shotsMeta,
+          basePrompt: toBlueprint(schemaConfig),
+          referencePrompts: {
+            tutorial: toBlueprint(tutorialConfig),
+            meetingSummary: toBlueprint(meetingConfig),
+          },
+          model: dspyOptions.model,
+          reflectionModel: dspyOptions.reflectionModel,
+          temperature: dspyOptions.temperature,
+          reflectionTemperature: dspyOptions.reflectionTemperature,
+          maxTokens: dspyOptions.maxTokens,
+          reflectionMaxTokens: dspyOptions.reflectionMaxTokens,
+          auto: (dspyOptions.auto ?? null) as DspyOptimizationPayload["auto"],
+          maxMetricCalls: dspyOptions.maxMetricCalls ?? null,
+          seed: dspyOptions.seed,
+          initialInstructions: dspyOptions.initialInstructions,
+          timeoutMs: dspyOptions.timeoutMs,
+          debug: dspyOptions.debug,
+        };
+
+        const optimized = await optimizePromptWithDSPy(optimizationPayload);
+
+        const parsed = Boolean(optimized.analysis?.parsed);
+        const personaCandidate = optimized.optimizedPrompt?.persona?.trim();
+        const requirementCandidate = optimized.optimizedPrompt?.requirements?.trim();
+        const fallbackCandidate = optimized.optimizedPrompt?.fallbackOutput?.trim();
+        const styleCandidate = optimized.optimizedPrompt?.styleGuide?.trim();
+
+        if (parsed && personaCandidate && requirementCandidate) {
+          personaText = personaCandidate;
+          requirementsText = requirementCandidate;
+          fallbackOutputText = fallbackCandidate || schemaConfig.fallbackOutput;
+          styleGuideText = styleCandidate || undefined;
+
+          promptMeta = {
+            requestedMode: promptMode,
+            appliedMode: "dspy",
+            score: optimized.analysis?.score,
+            coverage: optimized.analysis?.coverage,
+            parsed: optimized.analysis?.parsed,
+            parseError: optimized.analysis?.parseError,
+            feedback: optimized.analysis?.feedback,
+            satisfied: optimized.analysis?.satisfied,
+            missing: optimized.analysis?.missing,
+            auto: optimized.analysis?.auto ?? null,
+            trainsetSize: optimized.analysis?.trainsetSize,
+            requestedModel: optimized.analysis?.requestedModel,
+            rawPrompt: optimized.optimizedPrompt?.raw,
+            message: "DSPy GEPA optimized prompt applied.",
+          };
+        } else {
+          promptMeta = {
+            requestedMode: promptMode,
+            appliedMode: "manual",
+            score: optimized.analysis?.score,
+            coverage: optimized.analysis?.coverage,
+            parsed: optimized.analysis?.parsed,
+            parseError: optimized.analysis?.parseError,
+            feedback: optimized.analysis?.feedback,
+            satisfied: optimized.analysis?.satisfied,
+            missing: optimized.analysis?.missing,
+            auto: optimized.analysis?.auto ?? null,
+            trainsetSize: optimized.analysis?.trainsetSize,
+            requestedModel: optimized.analysis?.requestedModel,
+            rawPrompt: optimized.optimizedPrompt?.raw,
+            message: optimized.analysis?.parsed
+              ? "DSPy output lacked required fields – manual prompt restored."
+              : optimized.analysis?.parseError
+                ? `DSPy prompt parse failed: ${optimized.analysis?.parseError}`
+                : "DSPy prompt unavailable – manual instructions used.",
+          };
+        }
+      } catch (error) {
+        console.error("DSPy optimization failed:", error);
+        promptMeta = {
+          requestedMode: promptMode,
+          appliedMode: "manual",
+          message: error instanceof Error ? error.message : "DSPy optimization failed",
+        };
+      }
+    }
 
     // Build multimodal contents: video + screenshots + instruction
+    const screenshotList = screenshots.map((s) => `${s.id} -> ${s.timecode}`).join("\n") || "(none)";
     const parts = [
       createPartFromUri(video.uri, video.mimeType),
       "\n\n",
-      schemaConfig.persona,
+      personaText,
       "\n\nRequirements:\n",
-      schemaConfig.requirements,
+      requirementsText,
+      ...(styleGuideText ? ["\n\nStyle Guide:\n", styleGuideText] : []),
       "\n\nProvided screenshots (id → timecode):\n",
-      screenshots.map((s) => `${s.id} -> ${s.timecode}`).join("\n"),
+      screenshotList,
       "\n\nIf the user provided a " + schemaConfig.hintLabel + " hint, align with it. Title hint: ",
       titleHint || "(none)",
       "\n\nOutput format:\n",
-      enforceSchema ? "Return STRICT JSON according to the provided schema." : schemaConfig.fallbackOutput,
+      enforceSchema ? "Return STRICT JSON according to the provided schema." : fallbackOutputText,
       "\n",
       // Add the screenshots as file parts at the end so the model can see them:
       ...screenshots.flatMap((s) => [createPartFromUri(s.uri, s.mimeType)]),
@@ -70,6 +210,13 @@ export async function POST(req: Request) {
 
     return NextResponse.json({
       rawText: resp.text ?? "",
+      promptMeta,
+      appliedPrompt: {
+        persona: personaText,
+        requirements: requirementsText,
+        fallbackOutput: fallbackOutputText,
+        styleGuide: styleGuideText,
+      },
     });
   } catch (err: unknown) {
     console.error("Generation error:", err);

--- a/components/VideoWorkbench.tsx
+++ b/components/VideoWorkbench.tsx
@@ -67,6 +67,9 @@ export default function VideoWorkbench() {
     setSchemaType,
     titleHint,
     setTitleHint,
+    promptMode,
+    setPromptMode,
+    promptMeta,
     showAdvanced,
     setShowAdvanced,
     readyToGenerate,
@@ -132,6 +135,9 @@ export default function VideoWorkbench() {
         setEnforceSchema={setEnforceSchema}
         titleHint={titleHint}
         setTitleHint={setTitleHint}
+        promptMode={promptMode}
+        setPromptMode={setPromptMode}
+        promptMeta={promptMeta}
         showAdvanced={showAdvanced}
         setShowAdvanced={setShowAdvanced}
         readyToGenerate={readyToGenerate}
@@ -146,6 +152,7 @@ export default function VideoWorkbench() {
         enforceSchema={enforceSchema}
         schemaType={schemaType}
         shots={shots}
+        promptMeta={promptMeta}
         onCopy={(type, message) => showToast(type, message)}
         onExportPdf={handleExportPdf}
         isExporting={isExporting}

--- a/components/workbench/OptionsSection.tsx
+++ b/components/workbench/OptionsSection.tsx
@@ -2,8 +2,9 @@
 "use client";
 
 import { BusyPhase } from "@/hooks/useVideoWorkbench";
-import { SchemaType } from "@/lib/types";
+import { PromptMode, PromptOptimizationMeta, SchemaType } from "@/lib/types";
 import Spinner from "./Spinner";
+import clsx from "clsx";
 
 // ShadCN/UI Components
 import {
@@ -61,6 +62,9 @@ type OptionsSectionProps = {
   setEnforceSchema: (value: boolean) => void;
   titleHint: string;
   setTitleHint: (value: string) => void;
+  promptMode: PromptMode;
+  setPromptMode: (value: PromptMode) => void;
+  promptMeta: PromptOptimizationMeta | null;
   showAdvanced: boolean;
   setShowAdvanced: (value: boolean) => void;
   readyToGenerate: boolean;
@@ -75,6 +79,9 @@ export default function OptionsSection({
   setEnforceSchema,
   titleHint,
   setTitleHint,
+  promptMode,
+  setPromptMode,
+  promptMeta,
   showAdvanced,
   setShowAdvanced,
   readyToGenerate,
@@ -203,6 +210,73 @@ export default function OptionsSection({
               }
               className="bg-white border-gray-300 text-gray-900 placeholder:text-gray-500 hover:bg-gray-50 focus:border-sky-500 focus:ring-sky-500/50"
             />
+          </div>
+
+          <div className="space-y-3">
+            <Label className="text-sm font-medium text-gray-700">Prompt Strategy</Label>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={busyPhase === "generate"}
+                onClick={() => setPromptMode("manual")}
+                className={clsx(
+                  "px-4 py-2 text-sm font-medium transition-colors",
+                  promptMode === "manual"
+                    ? "border-indigo-500 bg-indigo-50 text-indigo-600 shadow-sm"
+                    : "border-gray-300 text-gray-700 hover:bg-gray-50",
+                )}
+              >
+                Manual prompt
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={busyPhase === "generate"}
+                onClick={() => setPromptMode("dspy")}
+                className={clsx(
+                  "px-4 py-2 text-sm font-medium transition-colors flex items-center gap-2",
+                  promptMode === "dspy"
+                    ? "border-purple-500 bg-purple-50 text-purple-600 shadow-sm"
+                    : "border-gray-300 text-gray-700 hover:bg-gray-50",
+                )}
+              >
+                DSPy GEPA
+                <Badge variant="outline" className="border-purple-200 text-purple-500 text-[10px]">
+                  beta
+                </Badge>
+              </Button>
+            </div>
+            <p className="text-xs text-gray-500">
+              Toggle between handcrafted guidance and DSPy 3 + GEPA optimized instructions.
+            </p>
+            {promptMeta && (
+              <div className="flex flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                <Badge
+                  variant="outline"
+                  className={`border ${
+                    promptMeta.appliedMode === "dspy"
+                      ? "border-purple-300 text-purple-600"
+                      : "border-gray-300 text-gray-600"
+                  }`}
+                >
+                  {promptMeta.appliedMode === "dspy" ? "DSPy applied" : "Manual prompt"}
+                </Badge>
+                <span className="font-medium text-gray-700">
+                  {promptMeta.message || "Prompt strategy evaluated."}
+                </span>
+                {typeof promptMeta.coverage === "number" && (
+                  <span className="text-[11px] text-gray-500">
+                    Coverage {(promptMeta.coverage * 100).toFixed(0)}%
+                  </span>
+                )}
+                {typeof promptMeta.score === "number" && (
+                  <span className="text-[11px] text-gray-500">
+                    Score {(promptMeta.score * 100).toFixed(0)}%
+                  </span>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Advanced Options */}

--- a/components/workbench/ResultSection.tsx
+++ b/components/workbench/ResultSection.tsx
@@ -3,7 +3,7 @@
 
 import { useCallback } from "react";
 import HowToViewer from "../HowToViewer";
-import { SchemaType } from "@/lib/types";
+import { PromptOptimizationMeta, SchemaType } from "@/lib/types";
 import { Shot } from "@/lib/types";
 import { safeStringify } from "@/lib/json";
 import { markdownToHtml } from "@/lib/markdown";
@@ -36,6 +36,7 @@ type ResultSectionProps = {
   enforceSchema: boolean;
   schemaType: SchemaType;
   shots: Shot[];
+  promptMeta: PromptOptimizationMeta | null;
   onCopy: (type: ToastState["type"], message: string) => void;
   onExportPdf: () => Promise<void>;
   isExporting: boolean;
@@ -48,6 +49,7 @@ export default function ResultSection({
   enforceSchema,
   schemaType,
   shots,
+  promptMeta,
   onCopy,
   onExportPdf,
   isExporting,
@@ -127,6 +129,31 @@ export default function ResultSection({
             <CardDescription className="text-sm text-gray-600">
               Toggle between a formatted view and raw JSON to verify Gemini output.
             </CardDescription>
+            {promptMeta && (
+              <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                <Badge
+                  variant="outline"
+                  className={`border ${
+                    promptMeta.appliedMode === "dspy"
+                      ? "border-purple-300 text-purple-600"
+                      : "border-gray-300 text-gray-600"
+                  }`}
+                >
+                  {promptMeta.appliedMode === "dspy" ? "DSPy optimized" : "Manual prompt"}
+                </Badge>
+                <span>{promptMeta.message || "Prompt strategy evaluated."}</span>
+                {typeof promptMeta.coverage === "number" && (
+                  <span className="text-[11px] text-gray-400">
+                    Coverage {(promptMeta.coverage * 100).toFixed(0)}%
+                  </span>
+                )}
+                {typeof promptMeta.score === "number" && (
+                  <span className="text-[11px] text-gray-400">
+                    Score {(promptMeta.score * 100).toFixed(0)}%
+                  </span>
+                )}
+              </div>
+            )}
           </div>
 
           <CardAction>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,8 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      "python/**",
+      ".python_lib/**",
     ],
   },
 ];

--- a/lib/dspy.ts
+++ b/lib/dspy.ts
@@ -1,0 +1,148 @@
+// lib/dspy.ts
+import { spawn } from "child_process";
+import { join } from "path";
+
+import { SchemaType } from "@/lib/types";
+
+export type PromptShotSummary = {
+  id: string;
+  timecode?: string;
+  label?: string;
+  note?: string;
+};
+
+export type PromptBlueprint = {
+  persona: string;
+  requirements: string;
+  fallbackOutput: string;
+  styleGuide?: string;
+  hintLabel?: string;
+};
+
+export type DspyAnalysis = {
+  score?: number;
+  coverage?: number;
+  parsed?: boolean;
+  parseError?: string;
+  feedback?: string;
+  satisfied?: string[];
+  missing?: string[];
+  auto?: string | null;
+  trainsetSize?: number;
+  requestedModel?: string;
+};
+
+export type OptimizedPrompt = {
+  persona?: string | null;
+  requirements?: string | null;
+  fallbackOutput?: string | null;
+  styleGuide?: string | null;
+  raw?: string;
+};
+
+export type DspyOptimizationResult = {
+  optimizedPrompt?: OptimizedPrompt;
+  analysis?: DspyAnalysis;
+  baselinePrompt?: PromptBlueprint;
+};
+
+export type DspyOptimizationPayload = {
+  schemaType: SchemaType;
+  enforceSchema: boolean;
+  titleHint?: string;
+  shots: PromptShotSummary[];
+  basePrompt: PromptBlueprint;
+  referencePrompts: Record<SchemaType, PromptBlueprint>;
+  model?: string;
+  reflectionModel?: string;
+  temperature?: number;
+  reflectionTemperature?: number;
+  maxTokens?: number;
+  reflectionMaxTokens?: number;
+  auto?: "light" | "medium" | "heavy" | null;
+  maxMetricCalls?: number | null;
+  seed?: number;
+  initialInstructions?: string;
+  timeoutMs?: number;
+  debug?: boolean;
+};
+
+const PYTHON_TIMEOUT_FALLBACK_MS = 90_000;
+
+function buildPythonEnv(): NodeJS.ProcessEnv {
+  const projectRoot = process.cwd();
+  const pythonPathEntries = [join(projectRoot, ".python_lib")];
+  const existing = process.env.PYTHONPATH;
+  if (existing) pythonPathEntries.push(existing);
+  const separator = process.platform === "win32" ? ";" : ":";
+
+  return {
+    ...process.env,
+    PYTHONPATH: pythonPathEntries.join(separator),
+  };
+}
+
+export async function optimizePromptWithDSPy(
+  payload: DspyOptimizationPayload,
+): Promise<DspyOptimizationResult> {
+  const scriptPath = join(process.cwd(), "python", "dspy_optimize.py");
+  const pythonBinary = process.env.DSPY_PYTHON || process.env.PYTHON || "python3";
+  const timeoutMs = payload.timeoutMs ?? Number(process.env.DSPY_TIMEOUT_MS ?? PYTHON_TIMEOUT_FALLBACK_MS);
+
+  return new Promise<DspyOptimizationResult>((resolve, reject) => {
+    const child = spawn(pythonBinary, [scriptPath], {
+      env: buildPythonEnv(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `DSPy optimizer exited with code ${code}`));
+        return;
+      }
+
+      const trimmed = stdout.trim();
+      if (!trimmed) {
+        reject(new Error("DSPy optimizer returned an empty response"));
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(trimmed) as DspyOptimizationResult;
+        resolve(parsed);
+      } catch (error) {
+        reject(new Error(`Failed to parse DSPy optimizer response: ${(error as Error).message}\nOutput: ${trimmed}`));
+      }
+    });
+
+    try {
+      child.stdin.write(JSON.stringify(payload));
+      child.stdin.end();
+    } catch (error) {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      reject(error);
+    }
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,3 +9,22 @@ export type Shot = {
 };
 
 export type SchemaType = "tutorial" | "meetingSummary";
+
+export type PromptMode = "manual" | "dspy";
+
+export type PromptOptimizationMeta = {
+  requestedMode: PromptMode;
+  appliedMode: PromptMode;
+  score?: number;
+  coverage?: number;
+  parsed?: boolean;
+  parseError?: string;
+  feedback?: string;
+  satisfied?: string[];
+  missing?: string[];
+  auto?: string | null;
+  trainsetSize?: number;
+  requestedModel?: string;
+  message?: string;
+  rawPrompt?: string;
+};

--- a/python/dspy_optimize.py
+++ b/python/dspy_optimize.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""DSPy GEPA prompt optimizer for Gemini instructions.
+
+This script reads JSON payloads from stdin and returns optimized prompt
+components suitable for the Next.js API route. It relies on DSPy 3 + GEPA
+and expects the `GEMINI_API_KEY` to be available for the underlying
+LiteLLM-backed Gemini models.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+import sys
+import textwrap
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from json_repair import repair_json
+
+try:
+    import dspy
+    from dspy.teleprompt import GEPA
+except Exception as exc:  # pragma: no cover - import guard
+    print(json.dumps({"error": f"DSPy import failed: {exc}"}), file=sys.stderr)
+    sys.exit(1)
+
+
+DEFAULT_INSTRUCTIONS = textwrap.dedent(
+    """
+    You are rewriting a system prompt that will be sent directly to Gemini.
+    Blend the base instructions with the optimization brief, making sure the
+    final guidance is specific, grounded, and pragmatic. Preserve the original
+    intent, but clarify any weak points called out in the brief.
+
+    Return STRICT JSON with the keys:
+      - persona (string)
+      - requirements (string with newline-separated bullet points)
+      - fallbackOutput (string)
+      - styleGuide (string, optional)
+
+    Do not invent data beyond what is provided. Explicitly mention screenshots
+    only when they appear in the brief. When schema enforcement is enabled,
+    remind Gemini to return valid JSON and repair minor format issues. When the
+    brief allows Markdown, highlight the expected structure. Keep the language
+    confident and actionable.
+    """
+).strip()
+
+
+@dataclass
+class PromptConfig:
+    persona: str
+    requirements: str
+    fallback_output: str
+    style_guide: Optional[str] = None
+
+
+def _strip_code_fence(text: str) -> str:
+    trimmed = text.strip()
+    if trimmed.startswith("```"):
+        trimmed = re.sub(r"^```[a-zA-Z]*", "", trimmed)
+        if "```" in trimmed:
+            trimmed = trimmed.rsplit("```", 1)[0]
+    return trimmed.strip()
+
+
+def _compose_prompt_text(config: Dict[str, Any]) -> str:
+    persona = config.get("persona", "").strip()
+    requirements = config.get("requirements", "").strip()
+    fallback = config.get("fallbackOutput", "").strip()
+    style = config.get("styleGuide", "").strip()
+    parts = [
+        "Persona:\n" + persona if persona else "",
+        "Requirements:\n" + requirements if requirements else "",
+        "Fallback Output:\n" + fallback if fallback else "",
+    ]
+    if style:
+        parts.append("Style Guide:\n" + style)
+    return "\n\n".join(part for part in parts if part)
+
+
+def _parse_prompt_json(raw_text: str) -> Tuple[Optional[PromptConfig], bool, Optional[str]]:
+    cleaned = _strip_code_fence(raw_text)
+    if not cleaned:
+        return None, False, "Empty response"
+
+    parse_error: Optional[str] = None
+    data: Optional[Dict[str, Any]] = None
+
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        try:
+            repaired = repair_json(cleaned)
+            data = json.loads(repaired)
+        except Exception as err:  # pragma: no cover - fallback path
+            parse_error = str(err)
+            data = None
+
+    if not isinstance(data, dict):
+        return None, False, parse_error or "Response is not a JSON object"
+
+    persona = str(data.get("persona", "")).strip()
+    requirements = data.get("requirements", "")
+    if isinstance(requirements, list):
+        requirements = "\n".join(str(item).strip() for item in requirements if str(item).strip())
+    requirements = str(requirements).strip()
+    fallback_output = str(data.get("fallbackOutput", data.get("fallback", ""))).strip()
+    style = data.get("styleGuide")
+    if isinstance(style, list):
+        style = "\n".join(str(item).strip() for item in style if str(item).strip())
+    style = str(style).strip() if style else None
+
+    return PromptConfig(persona=persona, requirements=requirements, fallback_output=fallback_output, style_guide=style), True, parse_error
+
+
+def _build_features(payload: Dict[str, Any]) -> List[str]:
+    schema_type = payload.get("schemaType", "tutorial")
+    enforce_schema = bool(payload.get("enforceSchema", False))
+    title_hint = payload.get("titleHint", "").strip()
+    shots: List[Dict[str, Any]] = payload.get("shots", []) or []
+
+    schema_focus = {
+        "tutorial": "Deliver a step-by-step tutorial grounded in the recording",
+        "meetingSummary": "Produce an executive-ready meeting summary with clear sections",
+    }.get(schema_type, "Deliver the requested output with clear structure")
+
+    features: List[str] = [schema_focus]
+    if shots:
+        ids = ", ".join(str(shot.get("id")) for shot in shots if shot.get("id"))
+        features.append(f"Explicitly reference screenshot IDs exactly as provided ({ids}) when relevant")
+        features.append("Use screenshot timecodes to reinforce chronological ordering")
+    else:
+        features.append("Clarify that screenshots may be absent and the video timeline should drive structure")
+
+    if title_hint:
+        features.append(f"Respect the optional title hint \"{title_hint}\" without copying verbatim")
+
+    if enforce_schema:
+        features.append("Remind Gemini to return STRICT JSON that matches the schema and repair minor formatting issues")
+    else:
+        features.append("Allow richly formatted Markdown when JSON enforcement is off, but keep sections explicit")
+
+    features.append("Emphasize grounding in both the video actions and any captured screenshots")
+
+    return features
+
+
+def _summarize_shots(shots: Iterable[Dict[str, Any]]) -> str:
+    entries: List[str] = []
+    for shot in shots:
+        identifier = str(shot.get("id", ""))
+        timecode = shot.get("timecode") or "?"
+        label = shot.get("label") or ""
+        note = shot.get("note") or ""
+        summary_parts = [identifier]
+        if timecode:
+            summary_parts.append(f"@{timecode}")
+        if label:
+            summary_parts.append(f"label: {label}")
+        if note:
+            summary_parts.append(f"note: {note}")
+        entries.append(" ".join(summary_parts))
+    return "; ".join(entries) if entries else "(no screenshots captured)"
+
+
+def _analyze_output(raw_text: str, features: List[str]) -> Dict[str, Any]:
+    parsed, parsed_ok, parse_error = _parse_prompt_json(raw_text)
+
+    if parsed and parsed_ok:
+        combined_text = " \n".join(
+            part
+            for part in [
+                parsed.persona,
+                parsed.requirements,
+                parsed.fallback_output,
+                parsed.style_guide or "",
+            ]
+            if part
+        )
+        json_bonus = 0.25
+    else:
+        combined_text = raw_text
+        json_bonus = 0.0
+
+    hits: List[str] = []
+    missing: List[str] = []
+    lowered = combined_text.lower()
+    for feature in features:
+        normalized = feature.lower()
+        if normalized and normalized in lowered:
+            hits.append(feature)
+        else:
+            missing.append(feature)
+
+    coverage = len(hits) / len(features) if features else 1.0
+    score = min(1.0, coverage + json_bonus)
+
+    feedback_parts: List[str] = []
+    if missing:
+        feedback_parts.append("Add guidance about: " + "; ".join(missing[:3]))
+        if len(missing) > 3:
+            feedback_parts.append(f"(+{len(missing) - 3} more coverage goals)")
+    if parse_error:
+        feedback_parts.append(f"Fix JSON formatting issues ({parse_error})")
+
+    feedback = " ".join(feedback_parts) if feedback_parts else "Prompt satisfies the optimization brief."
+
+    return {
+        "parsed": bool(parsed and parsed_ok),
+        "parseError": parse_error,
+        "score": round(score, 4),
+        "coverage": round(coverage, 4),
+        "satisfied": hits,
+        "missing": missing,
+        "feedback": feedback,
+        "persona": parsed.persona if parsed else None,
+        "requirements": parsed.requirements if parsed else None,
+        "fallbackOutput": parsed.fallback_output if parsed else None,
+        "styleGuide": parsed.style_guide if parsed else None,
+    }
+
+
+def _build_trainset(payload: Dict[str, Any]) -> Tuple[List[dspy.Example], str, str, List[str]]:
+    reference_prompts: Dict[str, Any] = payload.get("referencePrompts", {}) or {}
+    shots = payload.get("shots", []) or []
+
+    foundation_examples: List[dspy.Example] = []
+    for schema_key, config in reference_prompts.items():
+        base_prompt_text = _compose_prompt_text(config)
+        friendly = "step-by-step tutorial" if schema_key == "tutorial" else "executive-ready meeting summary"
+        features = [
+            f"Keep the persona oriented around an {friendly}",
+            "Spell out how to cite screenshot IDs exactly as provided",
+            "Mention grounding in both timeline and screenshots",
+            "Clarify how to behave when JSON schema enforcement is toggled",
+        ]
+        foundation_examples.append(
+            dspy.Example(
+                context_summary=(
+                    f"We are optimizing prompts for {friendly} outputs generated from product recordings. "
+                    "Screenshots typically include identifiers such as s1, s2, s3 with associated timecodes."
+                ),
+                base_prompt=base_prompt_text,
+                optimization_brief="\n".join(f"- {item}" for item in features),
+                expected_keywords=features,
+            ).with_inputs("context_summary", "base_prompt", "optimization_brief")
+        )
+
+    base_prompt = payload.get("basePrompt") or reference_prompts.get(payload.get("schemaType")) or {}
+    base_prompt_text = _compose_prompt_text(base_prompt)
+    features = _build_features(payload)
+    shots_summary = _summarize_shots(shots)
+
+    enforce_schema = bool(payload.get("enforceSchema", False))
+    title_hint = payload.get("titleHint", "").strip()
+    schema_type = payload.get("schemaType", "tutorial")
+    schema_label = "tutorial" if schema_type == "tutorial" else "meeting summary"
+
+    request_context_summary = textwrap.dedent(
+        f"""
+        Optimize the Gemini prompt for a {schema_label}. The video has {len(shots)} captured screenshots: {shots_summary}.
+        Schema enforcement is {'enabled' if enforce_schema else 'disabled'}.
+        Title hint provided: {title_hint or '(none)'}.
+        """
+    ).strip()
+
+    request_example = dspy.Example(
+        context_summary=request_context_summary,
+        base_prompt=base_prompt_text,
+        optimization_brief="\n".join(f"- {item}" for item in features),
+        expected_keywords=features,
+    ).with_inputs("context_summary", "base_prompt", "optimization_brief")
+
+    trainset = foundation_examples + [request_example]
+    return trainset, request_context_summary, base_prompt_text, features
+
+
+def _prepare_metric() -> Any:
+    def metric(gold: dspy.Example, pred: dspy.Prediction, *_: Any, **__: Any) -> Dict[str, Any]:
+        raw = getattr(pred, "optimized_prompt", "")
+        features = getattr(gold, "expected_keywords", []) or []
+        analysis = _analyze_output(raw, features)
+        return {"score": analysis["score"], "feedback": analysis["feedback"]}
+
+    return metric
+
+
+def _make_signature(initial_instructions: str):
+    class PromptOptimizationSignature(dspy.Signature):
+        """Rewrite Gemini system prompts so that they satisfy detailed briefs."""
+
+        context_summary = dspy.InputField(desc="Summary of the scenario we are optimizing for.")
+        base_prompt = dspy.InputField(desc="The prompt currently used to steer Gemini.")
+        optimization_brief = dspy.InputField(desc="Bullet list describing every improvement that must be reflected.")
+        optimized_prompt = dspy.OutputField(
+            desc=(
+                "Return STRICT JSON with persona, requirements, fallbackOutput, and optional styleGuide fields. "
+                "Requirements must remain newline-separated bullet points."
+            )
+        )
+
+        instructions = initial_instructions
+
+    return PromptOptimizationSignature
+
+
+class PromptOptimizer(dspy.Module):
+    def __init__(self, instructions: str):
+        super().__init__()
+        signature_cls = _make_signature(instructions)
+        self.rewrite = dspy.Predict(signature_cls)
+
+    def forward(self, context_summary: str, base_prompt: str, optimization_brief: str) -> dspy.Prediction:
+        return self.rewrite(
+            context_summary=context_summary,
+            base_prompt=base_prompt,
+            optimization_brief=optimization_brief,
+        )
+
+
+def run(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if not os.environ.get("GEMINI_API_KEY"):
+        raise RuntimeError("GEMINI_API_KEY environment variable is required for DSPy GEPA optimization")
+
+    initial_instructions = payload.get("initialInstructions") or DEFAULT_INSTRUCTIONS
+
+    model_name = payload.get("model") or "gemini/gemini-2.0-flash-exp"
+    temperature = float(payload.get("temperature", 0.2))
+    max_tokens = int(payload.get("maxTokens", 2048))
+
+    dspy.settings.configure(
+        lm=dspy.LM(model=model_name, temperature=temperature, max_tokens=max_tokens, cache=False)
+    )
+
+    reflection_model = payload.get("reflectionModel") or payload.get("model") or model_name
+    reflection_temperature = float(payload.get("reflectionTemperature", 0.7))
+    reflection_max_tokens = int(payload.get("reflectionMaxTokens", 4096))
+
+    reflection_lm = dspy.LM(
+        model=reflection_model,
+        temperature=reflection_temperature,
+        max_tokens=reflection_max_tokens,
+        cache=False,
+    )
+
+    trainset, request_context_summary, base_prompt_text, request_features = _build_trainset(payload)
+
+    metric = _prepare_metric()
+
+    optimizer = PromptOptimizer(initial_instructions)
+
+    auto = payload.get("auto")
+    max_metric_calls = payload.get("maxMetricCalls")
+    if not auto and not max_metric_calls:
+        auto = "light"
+
+    gepa = GEPA(
+        metric=metric,
+        auto=auto,
+        max_metric_calls=max_metric_calls,
+        reflection_lm=reflection_lm,
+        seed=int(payload.get("seed", random.randint(0, 10_000))),
+        track_stats=False,
+        skip_perfect_score=True,
+        add_format_failure_as_feedback=True,
+    )
+
+    optimized_program = gepa.compile(optimizer, trainset=trainset)
+
+    prediction = optimized_program(
+        context_summary=request_context_summary,
+        base_prompt=base_prompt_text,
+        optimization_brief="\n".join(f"- {item}" for item in request_features),
+    )
+
+    raw_prompt = getattr(prediction, "optimized_prompt", "")
+    final_analysis = _analyze_output(raw_prompt, request_features)
+
+    result = {
+        "ok": True,
+        "optimizedPrompt": {
+            "persona": final_analysis.get("persona"),
+            "requirements": final_analysis.get("requirements"),
+            "fallbackOutput": final_analysis.get("fallbackOutput"),
+            "styleGuide": final_analysis.get("styleGuide"),
+            "raw": raw_prompt,
+        },
+        "analysis": {
+            "score": final_analysis.get("score"),
+            "coverage": final_analysis.get("coverage"),
+            "parsed": final_analysis.get("parsed"),
+            "parseError": final_analysis.get("parseError"),
+            "feedback": final_analysis.get("feedback"),
+            "satisfied": final_analysis.get("satisfied"),
+            "missing": final_analysis.get("missing"),
+            "auto": auto,
+            "trainsetSize": len(trainset),
+            "requestedModel": model_name,
+        },
+        "baselinePrompt": payload.get("basePrompt"),
+    }
+
+    return result
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:  # pragma: no cover - invalid input guard
+        print(json.dumps({"error": f"Invalid JSON payload: {exc}"}), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = run(payload)
+    except Exception as exc:  # pragma: no cover - runtime guard
+        debug = payload.get("debug", False)
+        message = f"DSPy optimization failed: {exc}"
+        if debug:
+            import traceback
+
+            traceback.print_exc()
+        print(json.dumps({"error": message}), file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+dspy-ai>=3.0.3
+json-repair>=0.50.0


### PR DESCRIPTION
## Summary
- integrate DSPy GEPA optimization into the Gemini generation route with a Node wrapper and Python script
- add a prompt strategy toggle plus DSPy feedback wiring across the workbench hook and UI
- document the DSPy workflow and update ignores/requirements for the new Python tooling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8954c87c8832b9bdfbfeff23a7d72